### PR TITLE
feat: add filtering by default tag per portal

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -76,5 +76,7 @@ module.exports = {
   // is used to create and show a privacy preference center / cookie banner
   // To learn more about how to configure and use this, please refer to the readme
   privacyPreferenceCenter:
-    process.env.GATSBY_PRIVACY_PREFERENCE_CENTER || 'true'
+    process.env.GATSBY_PRIVACY_PREFERENCE_CENTER || 'true',
+
+  portalDDOTag: process.env.GATSBY_PORTAL_DDO_TAG || 'udlscienceportal'
 }

--- a/src/components/atoms/Tags.tsx
+++ b/src/components/atoms/Tags.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Link } from 'gatsby'
 import shortid from 'shortid'
 import styles from './Tags.module.css'
+import { useSiteMetadata } from '../../hooks/useSiteMetadata'
 
 declare type TagsProps = {
   items: string[]
@@ -39,12 +40,14 @@ const Tags: React.FC<TagsProps> = ({
   const tags = items.filter((tag) => tag !== '').slice(0, max)
   const shouldShowMore = showMore && remainder > 0
   const classes = className ? `${styles.tags} ${className}` : styles.tags
-
+  const { portalDDOTag } = useSiteMetadata().appConfig
   return (
     <div className={classes}>
-      {tags?.map((tag) => (
-        <Tag tag={tag} noLinks={noLinks} key={shortid.generate()} />
-      ))}
+      {tags
+        ?.filter((tag) => tag !== portalDDOTag)
+        .map((tag) => (
+          <Tag tag={tag} noLinks={noLinks} key={shortid.generate()} />
+        ))}
       {shouldShowMore && (
         <span className={styles.more}>{`+ ${items.length - max} more`}</span>
       )}

--- a/src/components/pages/Home/index.tsx
+++ b/src/components/pages/Home/index.tsx
@@ -11,7 +11,6 @@ import { useCancelToken } from '../../../hooks/useCancelToken'
 import { SearchQuery } from '../../../models/aquarius/SearchQuery'
 import {
   SortDirectionOptions,
-  SortOptions,
   SortTermOptions
 } from '../../../models/SortAndFilters'
 import { BaseQueryParams } from '../../../models/aquarius/BaseQueryParams'

--- a/src/hooks/usePublish.ts
+++ b/src/hooks/usePublish.ts
@@ -10,6 +10,7 @@ import { publishFeedback } from '../utils/feedback'
 import { useOcean } from '../providers/Ocean'
 import { useWeb3 } from '../providers/Web3'
 import { getOceanConfig } from '../utils/ocean'
+import { portalDDOTag } from '../../app.config'
 
 interface DataTokenOptions {
   cap?: string
@@ -125,9 +126,21 @@ function usePublish(): UsePublish {
 
       Logger.log('services created', services)
 
+      const assetWithPortalTag: Metadata = {
+        ...asset,
+        additionalInformation: {
+          ...asset.additionalInformation,
+          tags: asset.additionalInformation.tags
+            ? asset.additionalInformation.tags.concat([portalDDOTag])
+            : [portalDDOTag]
+        }
+      }
+
+      Logger.log('publishing with metadata', assetWithPortalTag)
+
       const ddo = await ocean.assets
         .create(
-          asset,
+          assetWithPortalTag,
           account,
           services,
           undefined,

--- a/src/hooks/useSiteMetadata.ts
+++ b/src/hooks/useSiteMetadata.ts
@@ -37,6 +37,7 @@ interface UseSiteMetadata {
     displayWarning: boolean
     defaultPrivacyPolicySlug: string
     privacyPreferenceCenter: string
+    portalDDOTag: string
   }
 }
 
@@ -78,6 +79,7 @@ const query = graphql`
           credentialType
           defaultPrivacyPolicySlug
           privacyPreferenceCenter
+          portalDDOTag
         }
       }
     }

--- a/src/utils/aquarius.ts
+++ b/src/utils/aquarius.ts
@@ -9,7 +9,11 @@ import { AssetSelectionAsset } from '../components/molecules/FormFields/AssetSel
 import { PriceList, getAssetsPriceList } from './subgraph'
 import axios, { CancelToken, AxiosResponse } from 'axios'
 import { OrdersData_tokenOrders as OrdersData } from '../@types/apollo/OrdersData'
-import { metadataCacheUri, allowDynamicPricing } from '../../app.config'
+import {
+  metadataCacheUri,
+  allowDynamicPricing,
+  portalDDOTag
+} from '../../app.config'
 import addressConfig from '../../address.config'
 import { PagedAssets } from '../models/PagedAssets'
 import { SearchQuery } from '../models/aquarius/SearchQuery'
@@ -87,6 +91,10 @@ export function generateBaseQuery(
           ...(baseQueryParams.filters || []),
           getFilterTerm('chainId', baseQueryParams.chainIds),
           getFilterTerm('_index', 'ocean'),
+          getFilterTerm(
+            'service.attributes.additionalInformation.tags',
+            portalDDOTag
+          ),
           ...(baseQueryParams.ignorePurgatory
             ? []
             : [getFilterTerm('isInPurgatory', 'false')])


### PR DESCRIPTION
Fixes #8 

## Proposed Changes

  - add default tag to app.config
  - filter all aquarius queries based on filter tag
  - add default tag to all published DDOs of this portal
  - remove default tag in taglist on asset detail pages

It looks like tags with hyphons or similar don't work when querying for them, so I opted for an "one-word" tag
